### PR TITLE
Update Question Service

### DIFF
--- a/question-service/README.md
+++ b/question-service/README.md
@@ -2,22 +2,42 @@
 Welcome to PeerPrep, your go-to platform for mastering technical interviews! PeerPrep is designed to help students like you sharpen their coding and problem-solving skills through collaborative learning. Our unique peer matching system connects you with fellow students to practice whiteboard-style interview questions together. Whether you're preparing for coding interviews at top tech companies or looking to enhance your problem-solving abilities, PeerPrep is your ultimate resource. Join our community, level up your technical interview skills, and increase your chances of success in the competitive world of tech recruitment. Happy coding!
 
 ## Setup Question Service
+Ensure your current working directory is the `question-service` folder.
 ```
-cd question-service
 npm install --global yarn
 yarn install
 yarn run dev
 ```
+This project uses NodeJS version v18.16.1 and `yarn` version 1.22.19.
+
+
 ### Setting up MongoDB
 1. Install [MongoDB](https://www.mongodb.com/docs/manual/installation/)
-1. Create a question-service database
-1. Create a question collection
-1. Add `mongodb://127.0.0.1:27017/question-service` to your `.env file` for `local_db_url` and set `ENV=DEV`. This is the default ip address and port for MongoDB. Note that newer versions of NodeJS may not resolve localhost properly.
+1. Create a `question-service` database
+1. Create a `questions` collection
+1. Create a `counters` collection and insert the following document:
+    ```
+    {
+        "collectionName": "questions",
+        "sequenceNum": 1
+    }
+    ```
 
-### Testing API
-You may use Postman to test the API but I prefer using Rest Client Extension within VSCode
+1. Lastly, create a file called `.env` in the `question-service` folder and add the following lines to it:
+    ```
+    ENV=DEV
+    local_db_url=mongodb://127.0.0.1:27017/question-service
+    question_collection_name=questions
+    counter_collection_name=counters
+    ```
 
-#### Installation
+    MongoDB uses the default IP address and port number of `127.0.0.1:27017`. Change these values accordingly if your MongoDB installation uses otherwise. Note that newer versions of NodeJS may not resolve the keyword `localhost` properly, so it is best to use `127.0.0.1` to explicitly refer to your local machine.
+
+
+## Testing API
+To test the API, you may use Postman or the Rest Client Extension within VSCode.
+
+### REST Client Extension Installation
 1. Open Visual Studio Code.
 
 1. Go to the Extensions view by clicking on the Extensions icon in the Activity Bar on the side of the window.
@@ -28,5 +48,29 @@ You may use Postman to test the API but I prefer using Rest Client Extension wit
 
 1. Once the installation is complete, you can access the extension from the Extensions view or the integrated terminal.
 
-#### Sending Requests
+### Sending Requests
 In the `route.rest` file, place the cursor anywhere in the request block and use the "Send Request" button on top of the block or you can right click anywhere in the request block and select "Send Request".
+
+
+## Sample Data
+The following is some sample data you can use to test the API:
+```
+{
+    "title": "Reverse a String",
+    "categories": ["Strings", "Algorithms"],
+    "complexity": "easy",
+    "description": "Write a function that reverses a string. The input string is given as an array of characters s.",
+    "link": "https://leetcode.com/problems/reverse-string/"
+}
+```
+
+```
+{
+  "title": "Implement Stack using Queues",
+  "categories": ["Stack", "Queue"],
+  "complexity": "medium",
+  "description": "Implement a stack using the standard library queue data structure.",
+  "link": "https://leetcode.com/problems/implement-stack-using-queues/"
+}
+```
+

--- a/question-service/index.js
+++ b/question-service/index.js
@@ -2,7 +2,9 @@ require('dotenv').config()
 const express = require('express')
 const app = express()
 const mongoose = require('mongoose')
-const port = 5000
+
+// Changed port to 3000, somehow using 5000 doesn't work?
+const port = 3000
 
 var api = process.env.ENV == 'DEV' ? process.env.LOCAL_DB_URL : process.env.PROD_DB_URL
 mongoose.connect(api, { useNewUrlParser: true, useUnifiedTopology: true })

--- a/question-service/index.js
+++ b/question-service/index.js
@@ -2,9 +2,7 @@ require('dotenv').config()
 const express = require('express')
 const app = express()
 const mongoose = require('mongoose')
-
-// Changed port to 3000, somehow using 5000 doesn't work?
-const port = 3000
+const port = 4000
 
 var api = process.env.ENV == 'DEV' ? process.env.LOCAL_DB_URL : process.env.PROD_DB_URL
 mongoose.connect(api, { useNewUrlParser: true, useUnifiedTopology: true })

--- a/question-service/models/counter-model.js
+++ b/question-service/models/counter-model.js
@@ -1,0 +1,15 @@
+require('dotenv').config()
+const mongoose = require('mongoose');
+
+const counterSchema = new mongoose.Schema({
+    collectionName: {
+        type: String,
+        required: true
+    },
+    sequenceNum: {
+        type: Number,
+        required: true
+    }
+});
+
+module.exports = mongoose.model('Counter', counterSchema, process.env.COUNTER_COLLECTION_NAME);

--- a/question-service/models/question-model.js
+++ b/question-service/models/question-model.js
@@ -1,6 +1,12 @@
+require('dotenv').config()
 const mongoose = require('mongoose');
 
 const questionSchema = new mongoose.Schema({
+    _id: {
+        type: Number,
+        required: true,
+        min: 1
+    },
     title: {
         type: String,
         required: true
@@ -26,5 +32,5 @@ const questionSchema = new mongoose.Schema({
         default: Date.now
     }
 });
-    
-module.exports = mongoose.model('Question', questionSchema);
+
+module.exports = mongoose.model('Question', questionSchema, process.env.QUESTION_COLLECTION_NAME);

--- a/question-service/routes/questions.js
+++ b/question-service/routes/questions.js
@@ -1,6 +1,22 @@
+require('dotenv').config()
 const express = require('express')
 const router = express.Router()
 const Question = require('../models/question-model')
+const Counter = require('../models/counter-model')
+
+
+// Helper function
+
+// Returns and increments the next sequence number for the questions collection
+async function getNextSequenceNum() {
+    filter = {collectionName: process.env.QUESTION_COLLECTION_NAME}
+    update = {$inc: {sequenceNum: 1}}
+
+    // Returns the value before the update
+    const result = await Counter.findOneAndUpdate(filter, update)
+    return result.sequenceNum
+}
+
 
 // Read questions
 router.get('/', async (req, res) => {
@@ -16,9 +32,11 @@ router.get('/:id', getQuestion, (req, res) => {
     res.json(res.question)
 })
 
+
 // Add a question
 router.post('/', async (req, res) => {
     const question = new Question({
+        _id: await getNextSequenceNum(),
         title: req.body.title,
         categories: req.body.categories,
         complexity: req.body.complexity,
@@ -32,6 +50,7 @@ router.post('/', async (req, res) => {
         res.status(400).json({ message: err.message })
     }
 })
+
 
 // Update a question
 router.patch('/:id', getQuestion, async (req, res) => {
@@ -58,6 +77,7 @@ router.patch('/:id', getQuestion, async (req, res) => {
     }
 })
 
+
 // Delete a question
 router.delete('/:id', getQuestion, async (req, res) => {
     try {
@@ -67,6 +87,7 @@ router.delete('/:id', getQuestion, async (req, res) => {
         res.status(500).json({ message: err.message })
     }
 })
+
 
 // middleware
 async function getQuestion(req, res, next) {


### PR DESCRIPTION
Modified the question ID field to automatically increment when adding a new question.

**Implementation Details**
MongoDB doesn't support auto increment fields by default. The workaround is to use another collection to store the ID number for the next question to be inserted.

This way, each time we add a new question, we will first retrieve the latest ID number, then use that result as the ID field of the question we are adding.