### PR TITLE
Implement socket-client functionality for Frontend

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -24,6 +24,7 @@
                 "react-dom": "18.2.0",
                 "react-icons": "^4.11.0",
                 "react-monaco-editor": "^0.54.0",
+                "socket.io-client": "^4.7.2",
                 "typescript": "5.1.6",
                 "y-webrtc": "^10.2.5",
                 "yjs": "^13.6.8"
@@ -1705,6 +1706,11 @@
                 "url": "https://opencollective.com/popperjs"
             }
         },
+        "node_modules/@socket.io/component-emitter": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+            "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+        },
         "node_modules/@swc/helpers": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
@@ -3220,6 +3226,46 @@
             "peer": true,
             "dependencies": {
                 "once": "^1.4.0"
+            }
+        },
+        "node_modules/engine.io-client": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.2.tgz",
+            "integrity": "sha512-CQZqbrpEYnrpGqC07a9dJDz4gePZUgTPMU3NKJPSeQOyw27Tst4Pl3FemKoFGAlHzgZmKjoRmiJvbWfhCXUlIg==",
+            "dependencies": {
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.3.1",
+                "engine.io-parser": "~5.2.1",
+                "ws": "~8.11.0",
+                "xmlhttprequest-ssl": "~2.0.0"
+            }
+        },
+        "node_modules/engine.io-client/node_modules/ws": {
+            "version": "8.11.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+            "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/engine.io-parser": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
+            "integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/enhanced-resolve": {
@@ -6286,6 +6332,32 @@
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "peer": true
         },
+        "node_modules/socket.io-client": {
+            "version": "4.7.2",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.2.tgz",
+            "integrity": "sha512-vtA0uD4ibrYD793SOIAwlo8cj6haOeMHrGvwPxJsxH7CeIksqJ+3Zc06RvWTIFgiSqx4A3sOnTXpfAEE2Zyz6w==",
+            "dependencies": {
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.3.2",
+                "engine.io-client": "~6.5.2",
+                "socket.io-parser": "~4.2.4"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/socket.io-parser": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+            "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+            "dependencies": {
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.3.1"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/source-list-map": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -7421,6 +7493,14 @@
                 "utf-8-validate": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/xmlhttprequest-ssl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+            "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/xtend": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -26,6 +26,7 @@
         "react-dom": "18.2.0",
         "react-icons": "^4.11.0",
         "react-monaco-editor": "^0.54.0",
+        "socket.io-client": "^4.7.2",
         "typescript": "5.1.6",
         "y-webrtc": "^10.2.5",
         "yjs": "^13.6.8"

--- a/Frontend/src/components/Matching/ConnectionManager.tsx
+++ b/Frontend/src/components/Matching/ConnectionManager.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { socket } from '@/lib/socket';
+import { Button } from '@chakra-ui/react';
+
+const ConnectionManager = () => {
+    function connect() {
+        socket.connect();
+    }
+
+    function disconnect() {
+        socket.disconnect();
+    }
+
+  return (
+    <div>
+        <Button onClick={connect}>Connect</Button>
+        <Button onClick={disconnect}>Disconnect</Button>
+    </div>
+  )
+}
+
+export default ConnectionManager

--- a/Frontend/src/components/Matching/MatchControls.tsx
+++ b/Frontend/src/components/Matching/MatchControls.tsx
@@ -4,6 +4,9 @@ import ConnectionManager from "./ConnectionManager";
 
 const MatchControls = () => {
   const [isConnected, setIsConnected] = useState(socket.connected);
+  const [timeElapsed, setTimeElapsed] = useState();
+  const [isMatched, setIsMatched] = useState(false);
+  const [matchedMessage, setMatchedMessage] = useState("");
 
   useEffect(() => {
     const onConnect = () => {
@@ -21,13 +24,15 @@ const MatchControls = () => {
     socket.on("disconnect", onDisconnect);
 
     socket.on("matchFound", (message) => {
-      console.log(message);
+      setIsMatched(true);
+      setTimeElapsed(undefined);
+      setMatchedMessage(message);
     });
     socket.on("matchTimerCountdown", (timerCountdown) => {
-      console.log("Time Elapsed: " + timerCountdown.toString());
+      setTimeElapsed(timerCountdown);
     });
     socket.on("noMatchTimerExpired", () => {
-      console.log("No Match Found!");
+      setMatchedMessage("No Match Found!");
     });
 
     return () => {
@@ -52,6 +57,8 @@ const MatchControls = () => {
       {isConnected && (
         <div>
           <h1>Client ID: {socket.id} </h1>
+          <h2>{timeElapsed}</h2>
+          {isMatched && <h2>{matchedMessage}</h2>}
         </div>
       )}
 

--- a/Frontend/src/components/Matching/MatchControls.tsx
+++ b/Frontend/src/components/Matching/MatchControls.tsx
@@ -1,12 +1,15 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { socket } from "../../lib/socket";
 import ConnectionManager from "./ConnectionManager";
+
+import { RoomContext } from "@/contexts/RoomContext";
 
 const MatchControls = () => {
   const [isConnected, setIsConnected] = useState(socket.connected);
   const [difficulty, setDifficulty] = useState("");
   const [status, setStatus] = useState("Select difficulty and click Start Match");
   const [timeElapsed, setTimeElapsed] = useState("30");
+  const { roomId, setRoomId } = useContext(RoomContext);
 
   useEffect(() => {
     const onConnect = () => {
@@ -17,14 +20,16 @@ const MatchControls = () => {
 
     const onDisconnect = () => {
       setIsConnected(false);
+      setRoomId("");
       console.log("disconnected");
     };
 
     socket.on("connect", onConnect);
     socket.on("disconnect", onDisconnect);
 
-    socket.on("matchFound", (message) => {
+    socket.on("matchFound", (message, roomId) => {
       setTimeElapsed("30");
+      setRoomId(roomId);
       setStatus(message);
     });
     socket.on("matchTimerCountdown", (timerCountdown) => {
@@ -43,7 +48,7 @@ const MatchControls = () => {
   return (
     <div style={{backgroundColor: "green"}}>
       <h1>Client ID: {socket.id} </h1>
-      <h1>{status}</h1>
+      <h1>{status + `Room ID: ${roomId}`}</h1>
       <h2>Select difficulty level:</h2>
       {!isConnected && (
         <div>

--- a/Frontend/src/components/Matching/MatchControls.tsx
+++ b/Frontend/src/components/Matching/MatchControls.tsx
@@ -1,0 +1,63 @@
+import React, { useState, useEffect } from "react";
+import { socket } from "../../lib/socket";
+import ConnectionManager from "./ConnectionManager";
+
+const MatchControls = () => {
+  const [isConnected, setIsConnected] = useState(socket.connected);
+
+  useEffect(() => {
+    const onConnect = () => {
+      setIsConnected(true);
+
+      socket.emit("startMatch", "easy");
+    };
+
+    const onDisconnect = () => {
+      setIsConnected(false);
+      console.log("disconnected");
+    };
+
+    socket.on("connect", onConnect);
+    socket.on("disconnect", onDisconnect);
+
+    socket.on("matchFound", (message) => {
+      console.log(message);
+    });
+    socket.on("matchTimerCountdown", (timerCountdown) => {
+      console.log("Time Elapsed: " + timerCountdown.toString());
+    });
+    socket.on("noMatchTimerExpired", () => {
+      console.log("No Match Found!");
+    });
+
+    return () => {
+      socket.off("connect", onConnect);
+      socket.off("disconnect", onDisconnect);
+    };
+  }, []);
+
+  return (
+    <div>
+      {!isConnected && (
+        <div>
+          <h1>Client ID:</h1>
+          <select id="difficulty">
+            <option value="easy">Easy</option>
+            <option value="medium">Medium</option>
+            <option value="hard">Hard</option>
+          </select>
+        </div>
+      )}
+
+      {isConnected && (
+        <div>
+          <h1>Client ID: {socket.id} </h1>
+        </div>
+      )}
+
+      <ConnectionManager />
+    </div>
+  );
+};
+
+export default MatchControls;

--- a/Frontend/src/components/Matching/MatchControls.tsx
+++ b/Frontend/src/components/Matching/MatchControls.tsx
@@ -4,15 +4,15 @@ import ConnectionManager from "./ConnectionManager";
 
 const MatchControls = () => {
   const [isConnected, setIsConnected] = useState(socket.connected);
-  const [timeElapsed, setTimeElapsed] = useState();
-  const [isMatched, setIsMatched] = useState(false);
-  const [matchedMessage, setMatchedMessage] = useState("");
+  const [difficulty, setDifficulty] = useState("");
+  const [status, setStatus] = useState("Select difficulty and click Start Match");
+  const [timeElapsed, setTimeElapsed] = useState("30");
 
   useEffect(() => {
     const onConnect = () => {
       setIsConnected(true);
-
-      socket.emit("startMatch", "easy");
+      setStatus(`Finding match with difficulty level ${difficulty}`);
+      socket.emit("startMatch", difficulty);
     };
 
     const onDisconnect = () => {
@@ -24,15 +24,14 @@ const MatchControls = () => {
     socket.on("disconnect", onDisconnect);
 
     socket.on("matchFound", (message) => {
-      setIsMatched(true);
-      setTimeElapsed(undefined);
-      setMatchedMessage(message);
+      setTimeElapsed("30");
+      setStatus(message);
     });
     socket.on("matchTimerCountdown", (timerCountdown) => {
       setTimeElapsed(timerCountdown);
     });
     socket.on("noMatchTimerExpired", () => {
-      setMatchedMessage("No Match Found!");
+      setStatus("No Match Found!");
     });
 
     return () => {
@@ -42,11 +41,13 @@ const MatchControls = () => {
   }, []);
 
   return (
-    <div>
+    <div style={{backgroundColor: "green"}}>
+      <h1>Client ID: {socket.id} </h1>
+      <h1>{status}</h1>
+      <h2>Select difficulty level:</h2>
       {!isConnected && (
         <div>
-          <h1>Client ID:</h1>
-          <select id="difficulty">
+          <select id="difficulty" onChange={(event) => setDifficulty(event.target.value)}>
             <option value="easy">Easy</option>
             <option value="medium">Medium</option>
             <option value="hard">Hard</option>
@@ -56,9 +57,7 @@ const MatchControls = () => {
 
       {isConnected && (
         <div>
-          <h1>Client ID: {socket.id} </h1>
           <h2>{timeElapsed}</h2>
-          {isMatched && <h2>{matchedMessage}</h2>}
         </div>
       )}
 

--- a/Frontend/src/contexts/RoomContext.tsx
+++ b/Frontend/src/contexts/RoomContext.tsx
@@ -1,0 +1,23 @@
+import React, { createContext, useState } from "react";
+
+export const RoomContext = createContext({
+  roomId: "",
+  setRoomId: (roomId: string) => {},
+});
+
+export const RoomContextProvider = ({ children }: { children: any }) => {
+  const [roomId, setRoomId] = useState("");
+
+  return (
+    <RoomContext.Provider
+      value={{
+        roomId,
+        setRoomId,
+      }}
+    >
+      {children}
+    </RoomContext.Provider>
+  );
+};
+
+export default RoomContextProvider;

--- a/Frontend/src/lib/socket.js
+++ b/Frontend/src/lib/socket.js
@@ -1,0 +1,7 @@
+import { io } from "socket.io-client";
+
+const URL = process.env.MATCHING_SERVICE_URL || "http://127.0.0.1:4000";
+
+export const socket = io(URL, {
+    autoConnect: false
+});

--- a/Frontend/src/pages/_app.tsx
+++ b/Frontend/src/pages/_app.tsx
@@ -1,14 +1,17 @@
 import type { AppProps } from "next/app";
 import "bulma/css/bulma.css";
-import { ChakraBaseProvider, extendTheme } from '@chakra-ui/react'
+import { ChakraBaseProvider, extendTheme } from "@chakra-ui/react";
 
-const theme = extendTheme({})
+import RoomContextProvider from "@/contexts/RoomContext";
+
+const theme = extendTheme({});
 
 export default function App({ Component, pageProps }: AppProps) {
-    return (
-        <ChakraBaseProvider theme={theme}>
-          <Component {...pageProps} />
-        </ChakraBaseProvider>
-    )
-    
+  return (
+    <RoomContextProvider>
+      <ChakraBaseProvider theme={theme}>
+        <Component {...pageProps} />
+      </ChakraBaseProvider>
+    </RoomContextProvider>
+  );
 }

--- a/Frontend/src/pages/index.tsx
+++ b/Frontend/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import Head from "next/head";
 import React from "react";
 import NavBar from '../components/Nav'
+import MatchControls from "@/components/Matching/MatchControls";
 
 const MainApp = () => {
     return (
@@ -23,6 +24,7 @@ const MainApp = () => {
                         peers.
                     </p>
                 </section>
+                <MatchControls />
             </main>
         </>
     );

--- a/matching-service/index.js
+++ b/matching-service/index.js
@@ -4,15 +4,20 @@ const http = require('http')
 const express = require('express')
 const { Server } = require('socket.io')
 const onStartMatch = require('./matchHandler')
+const cors = require("cors");
 
 
 const hostname = '127.0.0.1'
 const port = 4000
 
 const app = express()
+app.use(cors());
 const server = http.createServer(app)
 const io = new Server(server, {
-    connectionStateRecovery: {}
+    connectionStateRecovery: {},
+    cors: {
+        origin: "http://localhost:3000"
+    }
 });
 
 

--- a/matching-service/matchHandler.js
+++ b/matching-service/matchHandler.js
@@ -137,7 +137,7 @@ function onStartMatch(io, socket, difficulty) {
         partner.socket.join(roomId)
 
         message = `Paired ${newUser.socket.id} and ${partner.socket.id}`;
-        io.to(roomId).emit('matchFound', message)
+        io.to(roomId).emit('matchFound', message, roomId)
 
         console.log(message)
 

--- a/matching-service/package-lock.json
+++ b/matching-service/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "cors": "^2.8.5",
         "express": "^4.18.2",
         "socket.io": "^4.7.2",
         "uuid": "^9.0.1"

--- a/matching-service/package.json
+++ b/matching-service/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^4.18.2",
     "socket.io": "^4.7.2",
     "uuid": "^9.0.1"


### PR DESCRIPTION
`Frontend` socket-client logic:
  * `MatchControls` component to handle the `socket.io-client` logic for the frontend to connect to the matching service. I basically just took the logic from the `index.html` file in the matching service and replicated that functionality here so users can select a difficulty and connect to the socket server as per the original functionality. To add functionality, you can just modify what exactly you want the client to do here on the different socket events.
  * `ConnectionManager` component is just two buttons for users to connect and disconnect from the socket server.
  * `socket.js` is where I create the socket and configure it to not connect automatically and only connect once a user clicks the connect button.

`Frontend` context logic:
  * `RoomContext` has two values that is `RoomId` and a function to `setRoomId`. And I wrapped the entire App in the `RoomContextProvider`. So with this, when two users are paired, we can set the `RoomId` to be the room that the two users are paired to and anywhere that we require this information, we can access it through the `RoomContext`.
  * To access the values in the context:
    1. Import the RoomContext
    2. Import useContext hook from react
    3. Then you can do `const { roomId, setRoomId } = useContext(RoomContext)` to access the values needed anywhere.

`matching-service` changes:
  * Enable cors
  * Changed the `matchHandler.js` such that once a match is found, it also returns the roomId to the frontend.  